### PR TITLE
Add mingw-w64 crt 11.0.1 to match headers and winpthreads

### DIFF
--- a/mingw-w64-crt-git/0001-Allow-to-use-bessel-and-complex-functions-without-un.patch
+++ b/mingw-w64-crt-git/0001-Allow-to-use-bessel-and-complex-functions-without-un.patch
@@ -1,0 +1,26 @@
+From 58ff03526ba9a0e5ebe2e318b54fdbe993d5abbd Mon Sep 17 00:00:00 2001
+From: Alexey Pavlov <alexpux@gmail.com>
+Date: Thu, 14 Sep 2017 11:13:45 +0300
+Subject: [PATCH 1/3] Allow to use bessel and complex functions without
+ undefining
+
+---
+ mingw-w64-headers/crt/math.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mingw-w64-headers/crt/math.h b/mingw-w64-headers/crt/math.h
+index 658abc80..7d5a26da 100644
+--- a/mingw-w64-headers/crt/math.h
++++ b/mingw-w64-headers/crt/math.h
+@@ -263,7 +263,7 @@ extern "C" {
+ #define EDOM 33
+ #define ERANGE 34
+ 
+-#ifndef __STRICT_ANSI__
++#if !defined(__STRICT_ANSI__) || defined(_POSIX_C_SOURCE) || defined(_POSIX_SOURCE) || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+ 
+ #ifndef _COMPLEX_DEFINED
+ #define _COMPLEX_DEFINED
+-- 
+2.14.1
+

--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -1,0 +1,100 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=crt
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=11.0.1
+pkgrel=1
+_commit='c3e587c067a00a561899d49d3e63a659e38802ec'
+pkgdesc='MinGW-w64 CRT for Windows'
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url='https://www.mingw-w64.org/'
+msys2_repository_url="https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-crt/"
+license=('custom')
+groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
+depends=("${MINGW_PACKAGE_PREFIX}-headers-git")
+makedepends=("git"
+             "${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-binutils"
+             "${MINGW_PACKAGE_PREFIX}-autotools")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+options=('!strip' '!buildflags' '!emptydirs')
+source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64#commit=$_commit"
+        0001-Allow-to-use-bessel-and-complex-functions-without-un.patch)
+sha256sums=('SKIP'
+            'd641257f7e1469aff89adc33e57702b75fe9667ca035978f890eae1020b6814c')
+
+pkgver() {
+  cd "${srcdir}/mingw-w64"
+  git describe --long ${_commit} | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g'
+}
+
+prepare() {
+  cd ${srcdir}/mingw-w64
+
+  git apply "${srcdir}/0001-Allow-to-use-bessel-and-complex-functions-without-un.patch"
+}
+
+build() {
+  msg "Building ${MSYSTEM} CRT"
+
+  declare -a _crt_configure_args
+  case "$CARCH" in
+    i686)
+      _crt_configure_args=("--disable-lib64" "--enable-lib32")
+    ;;
+    x86_64)
+      _crt_configure_args=("--disable-lib32" "--enable-lib64")
+    ;;
+    armv7)
+      _crt_configure_args=("--disable-lib32" "--disable-lib64" "--enable-libarm32")
+    ;;
+    aarch64)
+      _crt_configure_args=("--disable-lib32" "--disable-lib64" "--disable-libarm32" "--enable-libarm64")
+    ;;
+  esac
+
+  # only clang+lld support this at the moment
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]]; then
+    _crt_configure_args+=("--enable-cfguard")
+  fi
+
+  local _default_msvcrt=msvcrt
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]] || [[ $MINGW_PACKAGE_PREFIX == *-ucrt-* ]]; then
+    _default_msvcrt=ucrt
+  fi
+
+  [[ -d ${srcdir}/build-${MSYSTEM} ]] && rm -rf ${srcdir}/build-${MSYSTEM}
+  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
+
+  ${srcdir}/mingw-w64/mingw-w64-crt/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --with-default-msvcrt=${_default_msvcrt} \
+    --enable-wildcard \
+    --disable-dependency-tracking \
+    "${_crt_configure_args[@]}"
+
+  make
+}
+
+package() {
+  msg "Installing ${MSYSTEM} crt"
+  cd ${srcdir}/build-${MSYSTEM}
+  make DESTDIR=${pkgdir} install-strip
+
+  # Create empty dummy archives, to avoid failing when the compiler driver
+  # adds -lssp -lssh_nonshared when linking.
+  ar rcs "${pkgdir}"${MINGW_PREFIX}/lib/libssp.a
+  ar rcs "${pkgdir}"${MINGW_PREFIX}/lib/libssp_nonshared.a
+
+  msg "Installing MinGW-w64 licenses"
+  install -Dm644 ${srcdir}/mingw-w64/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+  install -Dm644 ${srcdir}/mingw-w64/COPYING.MinGW-w64/COPYING.MinGW-w64.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.MinGW-w64.txt
+  install -Dm644 ${srcdir}/mingw-w64/COPYING.MinGW-w64-runtime/COPYING.MinGW-w64-runtime.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.MinGW-w64-runtime.txt
+}


### PR DESCRIPTION
Companion to r-windows/gcc-13#1, same recipe for the clang64/clangarm64 toolchains.

The repo pins `headers-git` and `winpthreads` at mingw-w64 11.0.1 (commit `c3e587c06`), but the crt falls through to msys2 upstream (14.0.0.r220), which removed `crt_handler.c` — including `_gnu_exception_handler`, still referenced by the 11.0.1 winpthreads static library from its thread SEH data. Linking any executable against the static winpthreads therefore fails with an undefined reference (first seen rebuilding grpc in r-windows/ucrt-libs#40, on all three targets).

This pins the crt at the same `c3e587c06` commit. Recipe copied from msys2/MINGW-packages `mingw-w64-crt-git` of the same era (aarch64 `--enable-libarm64` and clang `--enable-cfguard` handling included); package named `crt` with `provides/conflicts/replaces crt-git` per the msys2 rename, so these repos shadow msys2's newer `crt` by repo order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)